### PR TITLE
Updating the googlesearch package name

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from google import search
+from googlesearch import search
 import os
 import argparse
 


### PR DESCRIPTION
Running the main.py throws 

**No module named 'google' error**

Fixed by updating the package name.